### PR TITLE
Specify JSON extension in require

### DIFF
--- a/src/isbinary.ts
+++ b/src/isbinary.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const BINARY_FILE_EXTENSIONS = require('../../extensions');
+const BINARY_FILE_EXTENSIONS = require('../../extensions.json');
 
 const binaryCharacters = [
   0, 1, 2, 3, 4,


### PR DESCRIPTION
With some configurations, require needs the file extension so that it doesn't try to load a module.